### PR TITLE
update fog to to fix net/ssh error

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,4 +10,4 @@ else
   raise "Sorry #{node['platform']} is not supported ..."
 end
 
-default['rsc_ros']['gems'] = { "fog" => "1.36.0", "mixlib-cli" => "1.5.0" }
+default['rsc_ros']['gems'] = { "fog" => "1.36.0", "mixlib-cli" => "1.5.0", 'mime-types'=>'1.25.0' }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,4 +10,4 @@ else
   raise "Sorry #{node['platform']} is not supported ..."
 end
 
-default['rsc_ros']['gems'] = { "fog" => "1.29.0", "mixlib-cli" => "1.5.0" }
+default['rsc_ros']['gems'] = { "fog" => "1.36.0", "mixlib-cli" => "1.5.0" }

--- a/files/default/ros.rb
+++ b/files/default/ros.rb
@@ -3,6 +3,7 @@
 require 'rubygems'
 require 'fog'
 require 'mixlib/cli'
+require 'mime-types'
 #setup options
 
 class MyCLI

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -26,6 +26,7 @@ describe 'rsc_ros::default' do
   it 'installs required gems' do
     expect(chef_run_ubuntu).to install_gem_package('fog')
     expect(chef_run_ubuntu).to install_gem_package('mixlib-cli')
+    expect(chef_run_ubuntu).to install_gem_package('mime-types')
   end
 
   it 'creates /usr/local/bin/ros.rb' do


### PR DESCRIPTION
fog needed to be updated because it was throwing an error for net/ssh.  the error was fixed in fog 1.36.