### PR TITLE
Update default.rb

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,5 +10,5 @@ else
   raise "Sorry #{node['platform']} is not supported ..."
 end
 
-default['rsc_ros']['gems'] = { "fog" => "1.36.0", "mixlib-cli" => "1.5.0", 'mime-types'=>'1.25.0' }
+default['rsc_ros']['gems'] = { "fog" = "1.36.0", "mixlib-cli" => "1.5.0", 'mime-types'=>'1.25.0' }
 default['rsc_ros']['timeout']=1200


### PR DESCRIPTION
currently when use rsc_ros we run into the error:

/usr/local/bin/ros.rb -t download -c aws -u xxxxxxxxx -p xxxxxxxxx -b kabam-rs-artifacts -f xlate2/xxxxxxxxxx.tgz -d /tmp/xlate2.tgz -r us-west-1, STDOUT:, STDERR:/var/lib/gems/1.9.1/gems/fog-profitbricks-2.0.1/lib/fog/profitbricks.rb:4:in `<top (required)>': undefined local variable or method `__dir__' for main:Object (NameError)

as the new fog-profitbricks use __dir__ instead of old __FILE__ which requires ruby version higher than 1.9.3