### PR TITLE
pinning fog-profitblocks at 0.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@ group :integration do
   gem 'rspec-expectations', '~> 2.14.0'
   gem 'buff-ignore','1.1.1'
   gem 'rack', '1.6.4'
+  gem 'json','~> 1.8.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,6 @@ group :integration do
   gem 'chefspec', '~> 3.4.0'
   gem 'travis-lint'
   gem 'rspec-expectations', '~> 2.14.0'
+  gem 'buff-ignore','1.1.1'
+  gem 'rack', '1.6.4'
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,5 +10,5 @@ else
   raise "Sorry #{node['platform']} is not supported ..."
 end
 
-default['rsc_ros']['gems'] = { "fog" => "1.36.0", "mixlib-cli" => "1.5.0", 'fog-profitblocks'=>'0.0.5' }
+default['rsc_ros']['gems'] = { "fog" => "1.36.0", "mixlib-cli" => "1.5.0", 'mime-types'=>'1.25.0', 'fog-profitblocks'=>'0.0.5' }
 default['rsc_ros']['timeout']=1200

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,5 +10,5 @@ else
   raise "Sorry #{node['platform']} is not supported ..."
 end
 
-default['rsc_ros']['gems'] = { "fog" => "1.36.0", "mixlib-cli" => "1.5.0", 'mime-types'=>'1.25.0', 'fog-profitblocks'=>'0.0.5' }
+default['rsc_ros']['gems'] = { "fog" => "1.36.0", "mixlib-cli" => "1.5.0", 'mime-types'=>'1.25.0', 'fog-profitbricks'=>'0.0.5' }
 default['rsc_ros']['timeout']=1200

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,5 +10,5 @@ else
   raise "Sorry #{node['platform']} is not supported ..."
 end
 
-default['rsc_ros']['gems'] = { "fog" => "1.36.0", "mixlib-cli" => "1.5.0", 'mime-types'=>'1.25.0' }
+default['rsc_ros']['gems'] = { "fog" => "1.36.0", "mixlib-cli" => "1.5.0", 'fog-profitblocks'=>'0.0.5' }
 default['rsc_ros']['timeout']=1200


### PR DESCRIPTION
fog-profitblocks gem was updated 2 days ago.  need to pin it to 0.0.5 which is the previous / known working version